### PR TITLE
Tile Caching and barscale units

### DIFF
--- a/R/barscale.R
+++ b/R/barscale.R
@@ -9,6 +9,7 @@
 #' "bottomright" or a vector of two coordinates (c(x, y)) are possible.
 #' @param style style of the legend, either "pretty" or "oldschool". The 
 #' "oldschool" style only uses the "size" parameter.   
+#' @param dist_unit Can be "mi" for miles, "m" for meters, or "km" for kilometers (default)
 #' @note This scale bar is not accurate on unprojected (long/lat) maps.
 #' @export
 #' @seealso \link{layoutLayer}
@@ -18,7 +19,8 @@
 #' plot(st_geometry(mtq), col = "grey60", border = "grey20")
 #' barscale(size = 5)
 #' barscale(size = 5, lwd = 2, cex = .9, pos = c(714000, 1596000))
-barscale <- function(size, lwd = 1.5, cex = 0.6, pos = "bottomright", style="pretty"){
+barscale <- function(size, lwd = 1.5, cex = 0.6, pos = "bottomright", style="pretty",
+  dist_unit="km"){
   # size = 10
   mapExtent <- par()$usr
   x <- mapExtent[1:2]
@@ -30,12 +32,13 @@ barscale <- function(size, lwd = 1.5, cex = 0.6, pos = "bottomright", style="pre
     size <- diff(x)/10
     size <- signif(size, digits = 0)
   }else{
-    # km to m 
-    size <- size * 1000
+    # convert distance into meters based on dist_unit
+    size_text <- as.character(size)
+    size <- unit_conversion(size, dist_unit)
   }
   
   # label
-  labelscale <- paste(size / 1000, "km", sep =" ")
+  labelscale <- paste(size_text, dist_unit, sep =" ")
   
   # xy pos
   xscale <- x[2] - inset * 0.5 - size
@@ -77,6 +80,12 @@ barscale <- function(size, lwd = 1.5, cex = 0.6, pos = "bottomright", style="pre
          })
 }
 
-
+#' Convert units
+unit_conversion <- function(size, dist_unit){
+  if(!dist_unit %in% c('km','m','mi')) stop("dist_unit must be 'km','m', or'mi'")
+  if(dist_unit=="km") size <- size * 1000
+  if(dist_unit=="mi") size <- size * 1609.344
+  return(size)
+}
 
 

--- a/R/barscale.R
+++ b/R/barscale.R
@@ -31,6 +31,7 @@ barscale <- function(size, lwd = 1.5, cex = 0.6, pos = "bottomright", style="pre
   if(missing(size) || is.null(size)){
     size <- diff(x)/10
     size <- signif(size, digits = 0)
+    size_text <- as.character(size/1000)
   }else{
     # convert distance into meters based on dist_unit
     size_text <- as.character(size)

--- a/R/getTiles.R
+++ b/R/getTiles.R
@@ -13,7 +13,8 @@
 #' FALSE otherwise. If x is an sf object with one POINT, crop is set to FALSE. 
 #' @param verbose if TRUE, tiles filepaths, zoom level and citation are displayed. 
 #' @param apikey Needed for Thunderforest maps.
-#' @param cachedir String containing cache directory. If FALSE, tiles are not cached.
+#' @param cachedir String containing cache directory. If TRUE, places a "tile.chache'
+#' folder in the working directory. If FALSE (default), tiles are not cached.
 #' @param forceDownload Re-download cached tiles?
 #' @details 
 #' Zoom levels are described on the OpenStreetMap wiki: 
@@ -177,6 +178,8 @@ dl_t <- function(x, z, ext, src, q, verbose, cachedir, forceDownload) {
   if(isFALSE(cachedir)) {
     cachedir <- tempdir()
   } else { 
+    # if cachedir==T, place in working directory
+    if(isTRUE(cachedir)) cachedir <- paste0(getwd(),'/tile.cache')
     #create the cachedir if it doesn't exist.
     if(!dir.exists(cachedir)) dir.create(cachedir)
     # uses subdirectories based on src to make the directory easier for users to navigate


### PR DESCRIPTION
Two quick feature additions - I was creating maps in a loop, and being able to cache the tiles sped up the process quite a bit. 

By default, getTiles behaves as before, only placing them in a tempdir. Now if cachedir is specified to a file path, it will save the tiles to that directory, allowing the files to be re-used if the function is called again. Useful for re-running the code in different sessions.

`forceDownload` will overwrite existing cached tiles.

example code:
```
cache_directory = your_directory_here
# takes 9 minutes the first time
t <- getTiles(x = mtq, type = "CartoDB", cachedir =cache_directory, zoom=15)
# takes seven minutes the second time
t <- getTiles(x = mtq, type = "CartoDB", cachedir =cache_directory, zoom=15)
```

I hope to work on an efficient raster caching system if this is accepted, which would really speed things up.

Second addition is the ability to use miles and meters in the barscale; pretty straightforward. I wrote the conversion in a separate function in case you'd want to add more unit types later.