### PR TITLE
mute warnings from sp::plot when PROJ >= 6 and GDAL >= 3

### DIFF
--- a/R/propTrianglesLayer.R
+++ b/R/propTrianglesLayer.R
@@ -85,7 +85,7 @@ propTrianglesLayer <- function(x, spdf, df, spdfid = NULL, dfid = NULL,
   sfdc <- (x2-x1)*(y2-y1)
   # sc <- sum(abs(dots[,var]),na.rm = TRUE)
   sc <- max(abs(dots[,var]),na.rm = TRUE)
-  if(add==FALSE){sp::plot(spdf)}
+  if(add==FALSE){suppressWarnings(sp::plot(spdf))}
   
   # TRIANGLE TOP
   dots$size1 <-  sqrt(dots[,var1]*k* sfdc / sc /2)


### PR DESCRIPTION
I've added a `suppressWarnings()` around `sp::plot()` which was causing `R CMD check` to fail on the test for `propTrianglesLayer()`, because **sp** warns when the WKT comment on `"CRS"` objects is discarded (in **sp**). When **sf** is built with PROJ >= 6 and GDAL >= 3 and **sf** >= 0.9, **sp** takes the WKT as the CRS definition, and complains when it isn't used. The problem is in **sp**, but we need to keep or control the warnings for a period as software and workflows move from Proj strings to WKT.